### PR TITLE
Ergebnis-Array im readdata.php Skript korrigiert

### DIFF
--- a/TW_Klima/readdata.php
+++ b/TW_Klima/readdata.php
@@ -35,7 +35,7 @@ if ($result->num_rows > 0) {
     }
 }
 header('Content-type: application/json');
-echo json_encode($result_array);
+echo json_encode($result_array[0]);
 
 $conn->close();
 


### PR DESCRIPTION
Die Umwandlung der aus der Datenbank abgefragten Daten für das Frontend erzeugt derzeit ein komisches Array [{0:{.....}]. Um das Array in ein für das Frontend sinnvolles umzuwandeln wird im letzten Schritt im PHP-Skript nur das erste Element in diesem Array ausgewählt und an das Frontend übergeben.